### PR TITLE
Add configurable diamond reveal pitch ramp

### DIFF
--- a/src/ease.js
+++ b/src/ease.js
@@ -36,4 +36,8 @@ export default class Ease {
   static easeOutQuad(x) {
     return 1 - (1 - x) * (1 - x);
   }
+
+  static easeInQuad(x) {
+    return x * x;
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -77,6 +77,8 @@ const opts = {
   bombRevealedSoundPath: bombRevealedSoundUrl,
   winSoundPath: winSoundUrl,
   gameStartSoundPath: gameStartSoundUrl,
+  diamondRevealPitchMin: 1.0,
+  diamondRevealPitchMax: 1.5,
 
   // Win pop-up
   winPopupShowDuration: 260,

--- a/src/mines.js
+++ b/src/mines.js
@@ -1136,7 +1136,7 @@ export async function createMinesGame(mount, opts = {}) {
                         Math.max(0, revealedSafe / Math.max(totalSafe - 1, 1))
                       );
                 const pitch =
-                  minPitch + (maxPitch - minPitch) * safeProgress;
+                  minPitch + (maxPitch - minPitch) * Ease.easeInQuad(safeProgress);
                 playSoundEffect("diamondRevealed", { speed: pitch });
               }
             }


### PR DESCRIPTION
## Summary
- add configuration options for the minimum and maximum pitch used for diamond reveal sounds
- ramp the diamond reveal sound speed based on how many safe tiles have been uncovered so far

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2bc4bdb2c83239b94cb282e72c981