### PR TITLE
Center Mines tiles within the board

### DIFF
--- a/src/mines.js
+++ b/src/mines.js
@@ -1161,9 +1161,9 @@ export async function createMinesGame(mount, opts = {}) {
     revealedSafe = 0;
     totalSafe = GRID * GRID - mines;
 
-    const { tileSize, gap, boardSize } = layoutSizes();
-    const startX = -boardSize / 2;
-    const startY = -boardSize / 2;
+    const { tileSize, gap, contentSize } = layoutSizes();
+    const startX = -contentSize / 2;
+    const startY = -contentSize / 2;
 
     for (let r = 0; r < GRID; r++) {
       for (let c = 0; c < GRID; c++) {
@@ -1186,15 +1186,16 @@ export async function createMinesGame(mount, opts = {}) {
   function layoutSizes() {
     const canvasSize = Math.min(app.renderer.width, app.renderer.height);
     const topSpace = 32;
-    const boardSize = Math.max(40, canvasSize - topSpace - 10);
-    const gap = Math.max(10, Math.floor(boardSize * 0.02));
+    const boardSpace = Math.max(40, canvasSize - topSpace - 10);
+    const gap = Math.max(10, Math.floor(boardSpace * 0.02));
     const totalGaps = gap * (GRID - 1);
-    const tileSize = Math.floor((boardSize - totalGaps) / GRID);
-    return { tileSize, gap, boardSize };
+    const tileSize = Math.floor((boardSpace - totalGaps) / GRID);
+    const contentSize = tileSize * GRID + totalGaps;
+    return { tileSize, gap, contentSize };
   }
 
   function centerBoard() {
-    board.position.set(app.renderer.width / 2, app.renderer.height / 2 + 12);
+    board.position.set(app.renderer.width / 2, app.renderer.height / 2);
     board.scale.set(1);
     positionWinPopup();
   }


### PR DESCRIPTION
## Summary
- compute the tile grid size from the resolved tile and gap measurements so it can be centered correctly inside the canvas
- remove the hard-coded vertical offset that was nudging the board down inside the Pixi stage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e391ac9d7883238aefd7209fa9cb12