### PR TITLE
Adjust win popup text positions relative to popup size

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ const opts = {
   diamondTexturePath: diamondTextureUrl,
   bombTexturePath: bombTextureUrl,
   iconSizePercentage: 0.7,
-  iconRevealedSizeOpacity: 0.4,
+  iconRevealedSizeOpacity: 0.2,
   iconRevealedSizeFactor: 0.7,
   cardsSpawnDuration: 350,
   revealAllIntervalDelay: 40,
@@ -87,7 +87,7 @@ const opts = {
   // Win pop-up
   winPopupShowDuration: 260,
   winPopupWidth: 260,
-  winPopupHeight: 220,
+  winPopupHeight: 200,
 
   // Event callback for when a card is selected
   onCardSelected: ({ row, col, tile }) => {
@@ -98,7 +98,7 @@ const opts = {
     }
   },
   onWin: () => {
-    game?.showWinPopup?.(24.75, "0.00000000");
+    game?.showWinPopup?.(24.75, "0.00000003");
   },
 };
 

--- a/src/mines.js
+++ b/src/mines.js
@@ -389,6 +389,11 @@ export async function createMinesGame(mount, opts = {}) {
       .roundRect(-popupWidth / 2, -popupHeight / 2, popupWidth, popupHeight, 28)
       .fill(PALETTE.winPopupBackground);
 
+    const multiplierVerticalOffset =
+      -popupHeight / 2 + popupHeight * 0.2;
+    const amountRowVerticalOffset =
+      popupHeight / 2 - popupHeight * 0.2;
+
     const multiplierText = new Text({
       text: "1.00×",
       style: {
@@ -400,7 +405,7 @@ export async function createMinesGame(mount, opts = {}) {
       },
     });
     multiplierText.anchor.set(0.5);
-    multiplierText.position.set(0, -20);
+    multiplierText.position.set(0, multiplierVerticalOffset);
 
     const amountRow = new Container();
 
@@ -439,7 +444,7 @@ export async function createMinesGame(mount, opts = {}) {
       const spacing = 12;
       coinContainer.position.set(amountText.width + spacing + coinRadius, 0);
       amountRow.pivot.set(amountRow.width / 2, amountRow.height / 2);
-      amountRow.position.set(0, 34);
+      amountRow.position.set(0, amountRowVerticalOffset);
     };
 
     layoutAmountRow();

--- a/src/mines.js
+++ b/src/mines.js
@@ -394,6 +394,19 @@ export async function createMinesGame(mount, opts = {}) {
     const amountRowVerticalOffset =
       popupHeight / 2 - popupHeight * 0.2;
 
+    const centerLine = new Graphics();
+    const centerLinePadding = 40;
+    const centerLineWidth = popupWidth - centerLinePadding * 2;
+    const centerLineThickness = 2;
+    centerLine
+      .rect(
+        -centerLineWidth / 2,
+        -centerLineThickness / 2,
+        centerLineWidth,
+        centerLineThickness
+      )
+      .fill(0x323232);
+
     const multiplierText = new Text({
       text: "1.00×",
       style: {
@@ -449,7 +462,7 @@ export async function createMinesGame(mount, opts = {}) {
 
     layoutAmountRow();
 
-    container.addChild(border, inner, multiplierText, amountRow);
+    container.addChild(border, inner, centerLine, multiplierText, amountRow);
 
     return {
       container,

--- a/src/mines.js
+++ b/src/mines.js
@@ -432,7 +432,7 @@ export async function createMinesGame(mount, opts = {}) {
         align: "center",
       },
     });
-    amountText.anchor.set(0, 0.5);
+    amountText.anchor.set(0.5);
     amountRow.addChild(amountText);
 
     const coinContainer = new Container();
@@ -455,8 +455,12 @@ export async function createMinesGame(mount, opts = {}) {
 
     const layoutAmountRow = () => {
       const spacing = 12;
-      coinContainer.position.set(amountText.width + spacing + coinRadius, 0);
-      amountRow.pivot.set(amountRow.width / 2, amountRow.height / 2);
+      const coinDiameter = coinRadius * 2;
+      const totalWidth = amountText.width + spacing + coinDiameter;
+
+      amountText.position.set(-(spacing / 2 + coinRadius), 0);
+      coinContainer.position.set(totalWidth / 2 - coinRadius, 0);
+
       amountRow.position.set(0, amountRowVerticalOffset);
     };
 

--- a/src/mines.js
+++ b/src/mines.js
@@ -390,14 +390,14 @@ export async function createMinesGame(mount, opts = {}) {
       .fill(PALETTE.winPopupBackground);
 
     const multiplierVerticalOffset =
-      -popupHeight / 2 + popupHeight * 0.2;
+      -popupHeight / 2 + popupHeight * 0.28;
     const amountRowVerticalOffset =
-      popupHeight / 2 - popupHeight * 0.2;
+      popupHeight / 2 - popupHeight * 0.25;
 
     const centerLine = new Graphics();
-    const centerLinePadding = 40;
+    const centerLinePadding = 70;
     const centerLineWidth = popupWidth - centerLinePadding * 2;
-    const centerLineThickness = 2;
+    const centerLineThickness = 5;
     centerLine
       .rect(
         -centerLineWidth / 2,
@@ -423,7 +423,7 @@ export async function createMinesGame(mount, opts = {}) {
     const amountRow = new Container();
 
     const amountText = new Text({
-      text: "0.00000000",
+      text: "0.0",
       style: {
         fill: 0xffffff,
         fontFamily,
@@ -454,7 +454,7 @@ export async function createMinesGame(mount, opts = {}) {
     amountRow.addChild(coinContainer);
 
     const layoutAmountRow = () => {
-      const spacing = 12;
+      const spacing = 20;
       const coinDiameter = coinRadius * 2;
       const totalWidth = amountText.width + spacing + coinDiameter;
 


### PR DESCRIPTION
## Summary
- compute win popup multiplier and amount text offsets as percentages of the popup height
- position the multiplier text and amount row using the proportional offsets so they scale with the popup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e39e89aa788323aa87f981b93c8bf0