### PR TITLE
Use server-provided currency icon in win popup and subscribe to updates

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1991,6 +1991,9 @@ const opts = {
   winPopupShowDuration: 260,
   winPopupWidth: 260,
   winPopupHeight: 200,
+  currencyRelay: serverRelay,
+  currencyVariation: "orange",
+  initialCurrencyName: "Euro",
 
   // Event callback for when a card is selected
   getMode: () => controlPanelMode,


### PR DESCRIPTION
### Motivation
- Replace the hard-coded Bitcoin icon in the win popup with the currency icon provided by the server and ensure the popup updates when the server currency changes.

### Description
- Import currency asset getters from `../currencyProvider.js` and add `resolveCurrencyAsset` to choose the proper asset by `currencyVariation` and `currencyName`.
- Replace bitcoin-specific SVG fetching/loading with generic `fetchCurrencySvgMarkup` / `loadCoinTexture` flows and update error messages accordingly.
- Add currency state and lifecycle functions: `setCurrencyName`, `subscribeToCurrencyUpdates`, and wire `subscribeToCurrencyUpdates()` into game initialization so the win popup refreshes automatically when `currencyUpdated` events arrive.
- Pass `currencyRelay`, `currencyVariation`, and `initialCurrencyName` through `opts` in `src/main.js` so the game layer receives server relay and initial currency configuration.

### Testing
- Started the dev server with `npm run dev` which launched Vite and reported the site as ready (succeeded).
- Executed a Playwright script that navigated to the demo page, invoked `window.game.showWinPopup(2.5, 123.45)`, and captured `artifacts/win-popup-currency.png` to validate the popup rendering (succeeded after retries).
- Note that a couple of earlier Playwright runs timed out or errored (script issues), but the final automated run produced a screenshot artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989fa8ad45c8323bc793a1015da6bd4)