### PR TITLE
Ignore zero-value bets

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1543,6 +1543,9 @@ function handleBetButtonClick() {
   if (betButtonMode === "cashout") {
     handleCashout();
   } else {
+    if (!hasPositiveBetAmount(getCurrentBetValue())) {
+      return;
+    }
     handleBet();
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent the Bet button from initiating a bet when the current bet amount is zero by short-circuiting the click handler.

### Description
- Add an early return in `handleBetButtonClick` that checks `hasPositiveBetAmount(getCurrentBetValue())` and does nothing when the check fails, implemented in `src/main.js`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989fe03e73c8323b099cb0ed0a6ce95)